### PR TITLE
Drop support for EOL Python 3.2-3.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ need to install the Python interpreter.
 At this time of writing, there are two versions of the Python Koans:
 
 * one for use with Python 2.7 (earlier versions are no longer supported)
-* one for Python 3.1+
+* one for Python 3.5+
 
 You should be able to work with newer Python versions, but older ones will
 likely give you problems.


### PR DESCRIPTION
Same as https://github.com/gregmalcolm/python_koans/pull/207 but for my fork.